### PR TITLE
Add new feedback message for single word answers and responses

### DIFF
--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -3,9 +3,7 @@ import string
 import time
 
 import gensim
-import matplotlib.pyplot as plt
 import numpy as np
-import numpy.linalg
 from nltk.corpus import stopwords
 from nltk import word_tokenize
 from nltk.data import find
@@ -114,6 +112,11 @@ def evaluation_function(response, answer, params):
                 dif = ans_score[0] - resp_score[0]
                 word = resp_score[1]
 
+        more_info_msg = f'Please provide more information about {word}' if word is not None else ''
+        feedback_msg = (
+            f"Cannot determine if the answer is correct ({'%.3f'%(w2v_similarity)}% similarity). {more_info_msg}" if len(response.split(' ')) > 1
+            else "Incorrect" )
+
         return {
             "is_correct": False,
             "result": {
@@ -124,7 +127,7 @@ def evaluation_function(response, answer, params):
                 "BOW_similarity_value": similarity,
                 "problematic_word": word
             },
-            "feedback": f"Cannot determine if the answer is correct ({'%.3f'%(w2v_similarity)}% similarity). {f'Please provide more information about {word}' if word is not None else ''}"
+            "feedback": feedback_msg,
         }
 
 

--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -112,10 +112,11 @@ def evaluation_function(response, answer, params):
                 dif = ans_score[0] - resp_score[0]
                 word = resp_score[1]
 
+        both_one_word = len(response.split(' ')) == 1 and len(answer.split(' ')) == 1
         more_info_msg = f'Please provide more information about {word}' if word is not None else ''
         feedback_msg = (
-            f"Cannot determine if the answer is correct ({'%.3f'%(w2v_similarity)}% similarity). {more_info_msg}" if len(response.split(' ')) > 1
-            else "Incorrect" )
+            "Incorrect" if both_one_word
+            else f"Cannot determine if the answer is correct ({'%.3f'%(w2v_similarity)}% similarity). {more_info_msg}" )
 
         return {
             "is_correct": False,


### PR DESCRIPTION
This simply changes the feedback message returned when the answer and response are both a single word, without changing the output for existing test cases.
  
Previously, when a single word answer was required, the message returned would include the answer, giving it away to the student. This will bring the output from this function more in line with the other eval functions available.